### PR TITLE
Add background and house imagery

### DIFF
--- a/images/city-bg.svg
+++ b/images/city-bg.svg
@@ -1,0 +1,21 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a0a2a"/>
+      <stop offset="100%" stop-color="#000"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8AA0FF" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+  <rect x="80" y="500" width="120" height="400" fill="#060606"/>
+  <rect x="260" y="450" width="150" height="450" fill="#080808"/>
+  <rect x="470" y="520" width="180" height="380" fill="#050505"/>
+  <rect x="710" y="470" width="150" height="430" fill="#070707"/>
+  <rect x="900" y="540" width="160" height="360" fill="#040404"/>
+  <rect x="1100" y="480" width="140" height="420" fill="#090909"/>
+  <rect x="1280" y="530" width="150" height="370" fill="#050505"/>
+</svg>

--- a/images/meridian-house.svg
+++ b/images/meridian-house.svg
@@ -1,0 +1,13 @@
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="frame" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0A0A0A"/>
+      <stop offset="100%" stop-color="#000"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#frame)"/>
+  <polygon points="150,600 400,100 650,600" fill="#0F0F0F" stroke="#1e1e1e"/>
+  <rect x="280" y="280" width="240" height="180" fill="#000" stroke="#2A2A2A"/>
+  <text x="400" y="380" text-anchor="middle" fill="#8AA0FF" font-size="48" font-family="ui-sans-serif, system-ui" letter-spacing="2">MERIDIAN</text>
+  <text x="400" y="430" text-anchor="middle" fill="#8AA0FF" font-size="48" font-family="ui-sans-serif, system-ui" letter-spacing="2">BLACK</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,11 @@
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    body { background: radial-gradient(60% 60% at 50% -10%, rgba(120,120,255,0.10), transparent 60%), #000; }
+    body {
+      background: radial-gradient(60% 60% at 50% -10%, rgba(120,120,255,0.10), transparent 60%),
+                  url('images/city-bg.svg') center/cover no-repeat fixed;
+      background-color: #000;
+    }
     .glass { background: rgba(255,255,255,0.06); backdrop-filter: blur(6px); border: 1px solid rgba(255,255,255,0.12); }
     .ring-soft { box-shadow: 0 0 0 1px rgba(255,255,255,0.10) inset; }
     .poster { aspect-ratio: 4/5; }
@@ -56,6 +60,15 @@
           <p class="text-sm text-zinc-300 mt-2">Authentication & settlement on audited ledgers. Discretion standard; records of sale issued post-event.</p>
         </div>
       </div>
+    </div>
+  </section>
+
+  <!-- HOUSE SECTION -->
+  <section class="max-w-6xl mx-auto px-6 py-14 grid md:grid-cols-2 gap-8 items-center">
+    <img src="images/meridian-house.svg" alt="Meridian Black Auction House" class="w-full rounded-lg shadow-lg" />
+    <div>
+      <h2 class="text-2xl md:text-3xl font-semibold">Meridian Black Auction House</h2>
+      <p class="mt-4 text-zinc-300 max-w-prose">A quiet monolith on the Kokkedawn waterline, the house hosts formal auctions of human-made works with exact provenance and permanent records.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- use city skyline artwork as page background
- introduce house section with illustration and description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ef5d7f308330a43844328ecf15e1