### PR TITLE
Rename mini game heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
     <!-- MINI GAME -->
     <section class="max-w-5xl mx-auto px-6 py-14">
       <p class="uppercase tracking-widest text-xs text-zinc-400 mb-3">Play</p>
-      <h2 class="text-2xl md:text-3xl font-semibold mb-4">Whack-a-Bid — Ditlev Cocktail</h2>
+      <h2 class="text-2xl md:text-3xl font-semibold mb-4">Wack-a-Bid</h2>
       <div class="glass rounded-xl p-6 space-y-4">
         <p class="text-zinc-300 text-sm">Outbid the AI bidder for the last Ditlev cocktail. Whack the bid button as it pops up before the timer expires.</p>
         <div class="grid md:grid-cols-2 gap-4 items-center">


### PR DESCRIPTION
## Summary
- Rename mini game header to "Wack-a-Bid"
- Remove reference to Ditlev cocktail in the heading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fab7aee08330bff6e20a3c398557