### PR TITLE
Fix countdown for Meridian Black launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,9 +168,9 @@
     </div>
   </footer>
   <script>
-    // Countdown to 8 Nov 18:00 CET (Europe/Copenhagen winter time)
+    // Countdown to 8 Nov 2025 18:00 CET (UTC+1)
     (function() {
-      const target = new Date(Date.UTC(2024, 10, 8, 17, 0, 0));
+      const target = new Date(Date.UTC(2025, 10, 8, 17, 0, 0));
       const el = document.getElementById('countdown');
       if (!el) return;
       function update() {


### PR DESCRIPTION
## Summary
- update the countdown timer target to 8 November 2025 at 18:00 CET (UTC+1)

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_690cf4b495e08330855104255cc2c80e